### PR TITLE
config for running flake8 in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django
 django-countries
+flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[flake8]
+ignore = F401,F403,F405


### PR DESCRIPTION
Hey Greg and Paul!

I've just been pottering around tonight. I put in a `circle.yml` file so that you can check out what continuous integration is like. I would connect [circle](circleci.com) myself, but it has to be done by an admin on the repo.

- By default circle will install the `requirements.txt` to a python2.7 environment
- Inside the config file, the test command will be `flake8`, which will do run pep8 and basic error checking
- flake8 can be configured inside the `tox.ini` file

I'm curious to see what you think!